### PR TITLE
Fix deprecation warning with utcnow

### DIFF
--- a/insigniaDNS.py
+++ b/insigniaDNS.py
@@ -1,6 +1,6 @@
 # insigniaDNS
 
-from datetime import datetime
+from datetime import datetime, timezone
 from json import loads
 from socket import socket, AF_INET, SOCK_DGRAM, gethostbyname
 from sys import platform
@@ -49,9 +49,7 @@ def get_ip():
         s.close()
     return IP
 
-
-EPOCH = datetime(1970, 1, 1)
-SERIAL = int((datetime.utcnow() - EPOCH).total_seconds())
+SERIAL = int(datetime.now(timezone.utc).timestamp())
 MY_IP = get_ip()
 
 print("+===============================+")


### PR DESCRIPTION
Using py 3.13.5 when using the tool, and it kept outputting this utcnow deprecation warning every time you would start the app, so this PR deals with it.

We also don't need the EPOCH variable, since the `datetime.timestamp()` function outputs the same value.